### PR TITLE
Add patient notes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -21,6 +22,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.note.Note;
 import seedu.address.model.patient.Address;
 import seedu.address.model.patient.Email;
 import seedu.address.model.patient.Name;
@@ -100,8 +102,9 @@ public class EditCommand extends Command {
         Email updatedEmail = editPatientDescriptor.getEmail().orElse(patientToEdit.getEmail());
         Address updatedAddress = editPatientDescriptor.getAddress().orElse(patientToEdit.getAddress());
         Set<Tag> updatedTags = editPatientDescriptor.getTags().orElse(patientToEdit.getTags());
+        TreeSet<Note> updatedNotes = patientToEdit.getNotes(); // not allowed to edit notes
 
-        return new Patient(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Patient(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedNotes);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -3,11 +3,17 @@ package seedu.address.logic.commands;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATIENTS;
+
+import java.util.List;
+import java.util.TreeSet;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.note.Note;
+import seedu.address.model.patient.Patient;
 
 /**
  * Adds a note to a patient in the address book.
@@ -22,7 +28,9 @@ public class NoteCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1"
             + PREFIX_NOTE_TITLE + "Patient has allergies!"
             + PREFIX_NOTE_CONTENT + "Allergies include:\n - Penicillin\n - Nuts";
-    private static final String MESSAGE_ARGUMENTS = "Index: %1$d, Note Title: %2$s, Note Content: %3$s";
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Note Title: %2$s, Note Content: %3$s";
+    public static final String MESSAGE_ADD_NOTE_SUCCESS = "Added note to Person: %1$s";
+    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Removed note from Person: %1$s";
 
     private final Index index;
     private final Note note;
@@ -39,10 +47,46 @@ public class NoteCommand extends Command {
         this.note = note;
     }
 
+    // @Override
+    // public CommandResult execute(Model model) throws CommandException {
+    //     throw new CommandException(String.format(MESSAGE_ARGUMENTS, index.getOneBased(), this.note.getTitle(),
+    //             this.note.getContent()));
+    // }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(String.format(MESSAGE_ARGUMENTS, index.getOneBased(), this.note.getTitle(),
-                this.note.getContent()));
+        List<Patient> lastShownList = model.getFilteredPatientList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+        }
+
+        Patient patientToEdit = lastShownList.get(index.getZeroBased());
+
+        // Copy existing notes and add the new note
+        TreeSet<Note> updatedNotes = new TreeSet<>(patientToEdit.getNotes());
+        updatedNotes.add(note);
+
+        // Create updated patient
+        Patient editedPatient = new Patient(
+                patientToEdit.getName(),
+                patientToEdit.getPhone(),
+                patientToEdit.getEmail(),
+                patientToEdit.getAddress(),
+                patientToEdit.getTags(),
+                updatedNotes);
+
+        model.setPatient(patientToEdit, editedPatient);
+        model.updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
+
+        return new CommandResult(generateSuccessMessage(editedPatient));
+    }
+
+    /**
+     * Generates a command execution success message when a note is added.
+     */
+    private String generateSuccessMessage(Patient patientToEdit) {
+        return String.format(MESSAGE_ADD_NOTE_SUCCESS, Messages.format(patientToEdit));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -1,24 +1,64 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.note.Note;
 
+/**
+ * Adds a note to a patient in the address book.
+ */
 public class NoteCommand extends Command {
     public static final String COMMAND_WORD = "note";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new note for the patient identified "
             + "by the index number used in the displayed patient list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_NOTE_TITLE + "[NOTE TITLE] " 
+            + PREFIX_NOTE_TITLE + "[NOTE TITLE] "
             + PREFIX_NOTE_CONTENT + "[NOTE CONTENT]\n"
             + "Example: " + COMMAND_WORD + " 1"
             + PREFIX_NOTE_TITLE + "Patient has allergies!"
             + PREFIX_NOTE_CONTENT + "Allergies include:\n - Penicillin\n - Nuts";
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Note command not implemented yet";
+    private static final String MESSAGE_ARGUMENTS = "Index: %1$d, Note Title: %2$s, Note Content: %3$s";
+
+    private final Index index;
+    private final Note note;
+
+    /**
+     * Creates a NoteCommand to add the specified {@code Note}
+     * @param index index of the patient in the filtered patient list
+     * @param title title of the note
+     * @param content content of the note
+     */
+    public NoteCommand(Index index, Note note) {
+        requireAllNonNull(index, note);
+        this.index = index;
+        this.note = note;
+    }
 
     @Override
-    public CommandResult execute(Model model) {
-        return new CommandResult("Note command executed");
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(String.format(MESSAGE_ARGUMENTS, index.getOneBased(), this.note.getTitle(),
+                this.note.getContent()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NoteCommand)) {
+            return false;
+        }
+
+        NoteCommand e = (NoteCommand) other;
+        return index.equals(e.index)
+                && this.note.getTitle().equals(e.note.getTitle())
+                && this.note.getContent().equals(e.note.getContent());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+
+import seedu.address.model.Model;
+
+public class NoteCommand extends Command {
+    public static final String COMMAND_WORD = "note";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new note for the patient identified "
+            + "by the index number used in the displayed patient list.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_NOTE_TITLE + "[NOTE TITLE] " 
+            + PREFIX_NOTE_CONTENT + "[NOTE CONTENT]\n"
+            + "Example: " + COMMAND_WORD + " 1"
+            + PREFIX_NOTE_TITLE + "Patient has allergies!"
+            + PREFIX_NOTE_CONTENT + "Allergies include:\n - Penicillin\n - Nuts";
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Note command not implemented yet";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult("Note command executed");
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,10 +8,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.note.Note;
 import seedu.address.model.patient.Address;
 import seedu.address.model.patient.Email;
 import seedu.address.model.patient.Name;
@@ -44,8 +46,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        TreeSet<Note> notes = new TreeSet<>(); // add command does not allow adding notes straight away
 
-        Patient patient = new Patient(name, phone, email, address, tagList);
+        Patient patient = new Patient(name, phone, email, address, tagList, notes);
 
         return new AddCommand(patient);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,7 +17,9 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.note.Note;
 
 /**
  * Parses user input.
@@ -76,6 +78,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case NoteCommand.COMMAND_WORD:
+            return new NoteCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,7 +19,6 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.note.Note;
 
 /**
  * Parses user input.
@@ -80,7 +79,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case NoteCommand.COMMAND_WORD:
-            return new NoteCommand();
+            return new NoteCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_NOTE = new Prefix("note/");
     public static final Prefix PREFIX_NOTE_TITLE = new Prefix("nt/");
     public static final Prefix PREFIX_NOTE_CONTENT = new Prefix("nc/");
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_NOTE = new Prefix("note/");
+    public static final Prefix PREFIX_NOTE_TITLE = new Prefix("nt/");
+    public static final Prefix PREFIX_NOTE_CONTENT = new Prefix("nc/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.NoteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.note.Note;
+
+/**
+ * Parses input arguments and creates a new {@code RemarkCommand} object
+ */
+public class NoteCommandParser implements Parser<NoteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * {@code NoteCommand}
+     * and returns a {@code NoteCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public NoteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NOTE_TITLE, PREFIX_NOTE_CONTENT);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE), ive);
+        }
+
+        String title = argMultimap.getValue(PREFIX_NOTE_TITLE).orElse("");
+        String content = argMultimap.getValue(PREFIX_NOTE_CONTENT).orElse("");
+
+        return new NoteCommand(index, new Note(title, content));
+    }
+}

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -1,5 +1,8 @@
 package seedu.address.model.note;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.time.LocalDateTime;
 
 /**
@@ -7,6 +10,9 @@ import java.time.LocalDateTime;
  * Notes have a many-to-one relationship with patients
  */
 public class Note implements Comparable<Note>{
+
+    public static final String TITLE_AND_CONTENT_CONSTRAINTS = "Title and content cannot be empty";
+
     private final String title;
     private final String content;
     private final LocalDateTime dateTimeCreated;
@@ -18,9 +24,16 @@ public class Note implements Comparable<Note>{
      * @param content content of the note
      */
     public Note(String title, String content) {
+        requireNonNull(title);
+        requireNonNull(content);
+        checkArgument(isValidTitleAndContent(title, content), TITLE_AND_CONTENT_CONSTRAINTS);
         this.title = title;
         this.content = content;
         this.dateTimeCreated = LocalDateTime.now();
+    }
+
+    public boolean isValidTitleAndContent(String title, String content) {
+        return !title.isEmpty() && !content.isEmpty();
     }
 
     /**

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -5,6 +5,9 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Class which encapsulates all the information and methods pertaining to notes
  * Notes have a many-to-one relationship with patients
@@ -20,18 +23,37 @@ public class Note implements Comparable<Note> {
     /**
      * Initializes a new Note object with the given title and content
      * dateTimeCreated is initialized to the current time
-     * @param title title of the note
+     * 
+     * @param title   title of the note
      * @param content content of the note
      */
-    public Note(String title, String content) {
+    public Note(@JsonProperty("title") String title,
+            @JsonProperty("content") String content) {
         requireAllNonNull(title, content);
-        checkArgument(isValidTitleAndContent(title, content), TITLE_AND_CONTENT_CONSTRAINTS);
+        checkArgument(isValidNote(title, content), TITLE_AND_CONTENT_CONSTRAINTS);
         this.title = title;
         this.content = content;
         this.dateTimeCreated = LocalDateTime.now();
     }
 
-    public boolean isValidTitleAndContent(String title, String content) {
+    @JsonCreator
+    /**
+     * Initializes a new Note object with the given title, content and LocalDateTime
+     * @param title title of the note
+     * @param content content of the note
+     * @param dateTimeCreated date and time the note was created
+     */
+    public Note(@JsonProperty("title") String title,
+                @JsonProperty("content") String content,
+                @JsonProperty("dateTimeCreated") LocalDateTime dateTimeCreated) {
+        requireAllNonNull(title, content);
+        checkArgument(isValidNote(title, content), TITLE_AND_CONTENT_CONSTRAINTS);
+        this.title = title;
+        this.content = content;
+        this.dateTimeCreated = dateTimeCreated;
+    }
+
+    public static boolean isValidNote(String title, String content) {
         return !title.isEmpty() && !content.isEmpty();
     }
 
@@ -72,6 +94,27 @@ public class Note implements Comparable<Note> {
     }
 
     /**
+     * Checks if two notes are equal
+     * @param other another object to compare with
+     * @return true if the two notes are equal, false otherwise
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Note)) {
+            return false;
+        }
+
+        Note otherNote = (Note) other;
+        return this.title.equals(otherNote.title)
+                && this.content.equals(otherNote.content)
+                && this.dateTimeCreated.equals(otherNote.dateTimeCreated);
+    }
+
+    /**
      * Returns a string representation of the note
      */
     @Override
@@ -79,9 +122,9 @@ public class Note implements Comparable<Note> {
         return "[" + this.title + "]";
     }
 
-    // @Override
-    // public int hashCode() {
-    //     return this.title.hashCode() + this.content.hashCode() + this.dateTimeCreated.hashCode();
-    // }
+    @Override
+    public int hashCode() {
+        return this.title.hashCode() + this.content.hashCode() + this.dateTimeCreated.hashCode();
+    }
 
 }

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -23,7 +23,6 @@ public class Note implements Comparable<Note> {
     /**
      * Initializes a new Note object with the given title and content
      * dateTimeCreated is initialized to the current time
-     * 
      * @param title   title of the note
      * @param content content of the note
      */
@@ -36,13 +35,13 @@ public class Note implements Comparable<Note> {
         this.dateTimeCreated = LocalDateTime.now();
     }
 
-    @JsonCreator
     /**
      * Initializes a new Note object with the given title, content and LocalDateTime
      * @param title title of the note
      * @param content content of the note
      * @param dateTimeCreated date and time the note was created
      */
+    @JsonCreator
     public Note(@JsonProperty("title") String title,
                 @JsonProperty("content") String content,
                 @JsonProperty("dateTimeCreated") LocalDateTime dateTimeCreated) {

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -76,8 +76,7 @@ public class Note implements Comparable<Note> {
      */
     @Override
     public String toString() {
-        return "Title: " + this.title + "\n" + "Content: " + this.content + "\n" + "Date and Time Created: "
-                + this.dateTimeCreated.toString();
+        return "[" + this.title + "]";
     }
 
     // @Override

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -1,7 +1,7 @@
 package seedu.address.model.note;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
 
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
  * Class which encapsulates all the information and methods pertaining to notes
  * Notes have a many-to-one relationship with patients
  */
-public class Note implements Comparable<Note>{
+public class Note implements Comparable<Note> {
 
     public static final String TITLE_AND_CONTENT_CONSTRAINTS = "Title and content cannot be empty";
 
@@ -24,8 +24,7 @@ public class Note implements Comparable<Note>{
      * @param content content of the note
      */
     public Note(String title, String content) {
-        requireNonNull(title);
-        requireNonNull(content);
+        requireAllNonNull(title, content);
         checkArgument(isValidTitleAndContent(title, content), TITLE_AND_CONTENT_CONSTRAINTS);
         this.title = title;
         this.content = content;
@@ -63,7 +62,9 @@ public class Note implements Comparable<Note>{
     /**
      * Enables sorting of notes based on date and time created
      * @param other another note object to compare with
-     * @return 0 if the two notes were created at the same time, a positive integer if this note was created after the other note, and a negative integer if this note was created before the other note
+     * @return 0 if the two notes were created at the same time, a positive integer if
+     *     this note was created after the other note, and a negative integer if this
+     *     note was created before the other note
      */
     @Override
     public int compareTo(Note other) {
@@ -78,5 +79,10 @@ public class Note implements Comparable<Note>{
         return "Title: " + this.title + "\n" + "Content: " + this.content + "\n" + "Date and Time Created: "
                 + this.dateTimeCreated.toString();
     }
+
+    // @Override
+    // public int hashCode() {
+    //     return this.title.hashCode() + this.content.hashCode() + this.dateTimeCreated.hashCode();
+    // }
 
 }

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -1,0 +1,69 @@
+package seedu.address.model.note;
+
+import java.time.LocalDateTime;
+
+/**
+ * Class which encapsulates all the information and methods pertaining to notes
+ * Notes have a many-to-one relationship with patients
+ */
+public class Note implements Comparable<Note>{
+    private final String title;
+    private final String content;
+    private final LocalDateTime dateTimeCreated;
+
+    /**
+     * Initializes a new Note object with the given title and content
+     * dateTimeCreated is initialized to the current time
+     * @param title title of the note
+     * @param content content of the note
+     */
+    public Note(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.dateTimeCreated = LocalDateTime.now();
+    }
+
+    /**
+     * Gets title of a note
+     * @return title of the note
+     */
+    public String getTitle() {
+        return this.title;
+    }
+
+    /**
+     * Gets content of a note
+     * @return content of the note
+     */
+    public String getContent() {
+        return this.content;
+    }
+
+    /**
+     * Gets the date and time the note was created
+     * @return LocalDateTime object, which stores the date and time the note was created
+     */
+    public LocalDateTime getDateTimeCreated() {
+        return this.dateTimeCreated;
+    }
+
+    /**
+     * Enables sorting of notes based on date and time created
+     * @param other another note object to compare with
+     * @return 0 if the two notes were created at the same time, a positive integer if this note was created after the other note, and a negative integer if this note was created before the other note
+     */
+    @Override
+    public int compareTo(Note other) {
+        return this.dateTimeCreated.compareTo(other.dateTimeCreated);
+    }
+
+    /**
+     * Returns a string representation of the note
+     */
+    @Override
+    public String toString() {
+        return "Title: " + this.title + "\n" + "Content: " + this.content + "\n" + "Date and Time Created: "
+                + this.dateTimeCreated.toString();
+    }
+
+}

--- a/src/main/java/seedu/address/model/patient/Patient.java
+++ b/src/main/java/seedu/address/model/patient/Patient.java
@@ -70,7 +70,7 @@ public class Patient {
     /**
      * Retrieves the ordered set of notes associated with the patient
      * @return an immutable navigable note set, which throws {@code UnsupportedOperationException}
-     * if modification is attempted.
+     *     if modification is attempted.
      */
     public NavigableSet<Note> getNotes() {
         return Collections.unmodifiableNavigableSet(notes);

--- a/src/main/java/seedu/address/model/patient/Patient.java
+++ b/src/main/java/seedu/address/model/patient/Patient.java
@@ -4,10 +4,13 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.note.Note;
 import seedu.address.model.tag.Tag;
 
 
@@ -25,6 +28,7 @@ public class Patient {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final TreeSet<Note> notes;
 
     /**
      * Every field must be present and not null.
@@ -36,6 +40,7 @@ public class Patient {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.notes = new TreeSet<>();
     }
 
     public Name getName() {
@@ -60,6 +65,15 @@ public class Patient {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Retrieves the ordered set of notes associated with the patient
+     * @return an immutable navigable note set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public NavigableSet<Note> getNotes() {
+        return Collections.unmodifiableNavigableSet(notes);
     }
 
     /**
@@ -95,13 +109,14 @@ public class Patient {
                 && phone.equals(otherPatient.phone)
                 && email.equals(otherPatient.email)
                 && address.equals(otherPatient.address)
-                && tags.equals(otherPatient.tags);
+                && tags.equals(otherPatient.tags)
+                && notes.equals(otherPatient.notes);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, notes);
     }
 
     @Override
@@ -112,6 +127,7 @@ public class Patient {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("notes", notes)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/patient/Patient.java
+++ b/src/main/java/seedu/address/model/patient/Patient.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -43,6 +42,19 @@ public class Patient {
         this.notes = new TreeSet<>();
     }
 
+    /**
+     * Every field must be present and not null.
+     */
+    public Patient(Name name, Phone phone, Email email, Address address, Set<Tag> tags, TreeSet<Note> notes) {
+        requireAllNonNull(name, phone, email, address, tags);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.notes = notes;
+    }
+
     public Name getName() {
         return name;
     }
@@ -72,8 +84,8 @@ public class Patient {
      * @return an immutable navigable note set, which throws {@code UnsupportedOperationException}
      *     if modification is attempted.
      */
-    public NavigableSet<Note> getNotes() {
-        return Collections.unmodifiableNavigableSet(notes);
+    public TreeSet<Note> getNotes() {
+        return this.notes;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedNote.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedNote.java
@@ -23,7 +23,7 @@ class JsonAdaptedNote {
      * Constructs a {@code JsonAdaptedNote} with the given {@code title}, {@code content} and {@code LocalDateTime}.
      */
     @JsonCreator
-    public JsonAdaptedNote(@JsonProperty("title") String title, 
+    public JsonAdaptedNote(@JsonProperty("title") String title,
             @JsonProperty("content") String content,
             @JsonProperty("dateTimeCreated") LocalDateTime dateTimeCreated) {
         this.title = title;

--- a/src/main/java/seedu/address/storage/JsonAdaptedNote.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedNote.java
@@ -1,0 +1,52 @@
+package seedu.address.storage;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.note.Note;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Tag}.
+ */
+class JsonAdaptedNote {
+
+    private final String title;
+    private final String content;
+    private final LocalDateTime dateTimeCreated;
+
+    /**
+     * Constructor for Jackson deserialization
+     * Constructs a {@code JsonAdaptedNote} with the given {@code title}, {@code content} and {@code LocalDateTime}.
+     */
+    @JsonCreator
+    public JsonAdaptedNote(@JsonProperty("title") String title, 
+            @JsonProperty("content") String content,
+            @JsonProperty("dateTimeCreated") LocalDateTime dateTimeCreated) {
+        this.title = title;
+        this.content = content;
+        this.dateTimeCreated = dateTimeCreated;
+    }
+
+    public JsonAdaptedNote(Note source) {
+        this.title = source.getTitle();
+        this.content = source.getContent();
+        this.dateTimeCreated = source.getDateTimeCreated();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Note} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     */
+    public Note toModelType() throws IllegalValueException {
+        if (!Note.isValidNote(this.title, this.content)) {
+            throw new IllegalValueException(Note.TITLE_AND_CONTENT_CONSTRAINTS);
+        }
+        return new Note(this.title, this.content, this.dateTimeCreated);
+    }
+
+}

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -40,6 +40,8 @@ public class PatientCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+    @FXML
+    private FlowPane notes;
 
     /**
      * Creates a {@code PatientCode} with the given {@code Patient} and index to display.

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -57,5 +57,8 @@ public class PatientCard extends UiPart<Region> {
         patient.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        patient.getNotes().stream()
+                .sorted(Comparator.comparing(note -> note.getDateTimeCreated()))
+                .forEach(note -> notes.getChildren().add(new Label(note.getTitle())));
     }
 }

--- a/src/main/resources/view/PatientListCard.fxml
+++ b/src/main/resources/view/PatientListCard.fxml
@@ -31,6 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <FlowPane fx:id="notes" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePatientAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePatientAddressBook.json
@@ -4,11 +4,26 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
-    "tags": [ "friends" ]
+    "tags": ["friends"],
+    "notes": [
+      {
+        "title": "4th Session with Alice",
+        "content": "Discussed progress",
+        "dateTimeCreated": "2023-03-11T12:00:00"
+      }
+    ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "pauline@example.com",
-    "address": "4th street"
+    "email": "alice@example.com",
+    "address": "123, Jurong West Ave 6, #08-111",
+    "tags": ["friends"],
+    "notes": [
+      {
+        "title": "4th Session with Alice",
+        "content": "Discussed progress",
+        "dateTimeCreated": "2023-03-11T12:00:00"
+      }
+    ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPatientsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPatientsAddressBook.json
@@ -1,46 +1,71 @@
 {
   "_comment": "AddressBook save file which contains the same Patient values as in TypicalPatients#getTypicalAddressBook()",
   "patients" : [ {
-    "name" : "Alice Pauline",
-    "phone" : "94351253",
-    "email" : "alice@example.com",
-    "address" : "123, Jurong West Ave 6, #08-111",
-    "tags" : [ "friends" ]
+    "name": "Alice Pauline",
+    "phone": "94351253",
+    "email": "alice@example.com",
+    "address": "123, Jurong West Ave 6, #08-111",
+    "tags": ["friends"],
+    "notes": [
+      {
+        "title": "4th Session with Alice",
+        "content": "Discussed progress",
+        "dateTimeCreated": "2023-03-11T12:00:00"
+      }
+    ]
   }, {
-    "name" : "Benson Meier",
-    "phone" : "98765432",
-    "email" : "johnd@example.com",
-    "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ "owesMoney", "friends" ]
+    "name": "Benson Meier",
+    "phone": "98765432",
+    "email": "johnd@example.com",
+    "address": "311, Clementi Ave 2, #02-25",
+    "tags": ["owesMoney", "friends"],
+    "notes": [
+      {
+        "title": "Benson is a piece of work",
+        "content": "He has many issues",
+        "dateTimeCreated": "2025-03-11T12:00:00"
+      }
+    ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes": [ ]
   }, {
-    "name" : "Daniel Meier",
-    "phone" : "87652533",
-    "email" : "cornelia@example.com",
-    "address" : "10th street",
-    "tags" : [ "friends" ]
+    "name": "Daniel Meier",
+    "phone": "87652533",
+    "email": "cornelia@example.com",
+    "address": "10th street",
+    "tags": ["friends"],
+    "notes": [
+      {
+        "title": "Daniel owes me money",
+        "content": "He owes me $4000",
+        "dateTimeCreated": "2025-03-12T12:00:00"
+      }
+    ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes": [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes": [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes": [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -36,6 +36,10 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_NOTE_TITLE_AMY = "Amy's new obsession";
+    public static final String VALID_NOTE_CONTENT_AMY = "Patient has a severe obsession with cats.";
+    public static final String VALID_NOTE_TITLE_BOB = "Bob's allergies";
+    public static final String VALID_NOTE_CONTENT_BOB = "Patient is allergic to penicillin.";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -37,16 +40,31 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Patient editedPatient = new PatientBuilder().build();
+        // Get the original patient we are editing
+        Patient firstPatient = model.getFilteredPatientList().get(INDEX_FIRST_PATIENT.getZeroBased());
+
+        // Build edited patient starting from the first patient, modifying all fields
+        Patient editedPatient = new PatientBuilder(firstPatient)
+                .withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .build();
+
+        // Build descriptor matching the intended edits
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(editedPatient).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PATIENT, descriptor);
 
-        String expectedMessage =
-                String.format(EditCommand.MESSAGE_EDIT_PATIENT_SUCCESS, Messages.format(editedPatient));
+        // Expected message
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PATIENT_SUCCESS,
+                Messages.format(editedPatient));
 
+        // Expected model, applying the changes
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPatient(model.getFilteredPatientList().get(0), editedPatient);
+        expectedModel.setPatient(firstPatient, editedPatient);
 
+        // Assert success
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
@@ -1,0 +1,25 @@
+// package seedu.address.logic.commands;
+
+// import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+// import static seedu.address.logic.commands.NoteCommand.MESSAGE_NOT_IMPLEMENTED_YET;
+// import static seedu.address.testutil.TypicalPatients.getTypicalAddressBook;
+
+// import org.junit.jupiter.api.Test;
+
+// import seedu.address.model.Model;
+// import seedu.address.model.ModelManager;
+// import seedu.address.model.UserPrefs;
+
+// /**
+//  * Contains integration tests (interaction with the Model) and unit tests for
+//  * RemarkCommand.
+//  */
+// public class NoteCommandTest {
+
+//     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+//     @Test
+//     public void execute() {
+//         assertCommandFailure(new NoteCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
+//     }
+// }

--- a/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
@@ -1,25 +1,55 @@
-// package seedu.address.logic.commands;
+package seedu.address.logic.commands;
 
-// import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-// import static seedu.address.logic.commands.NoteCommand.MESSAGE_NOT_IMPLEMENTED_YET;
-// import static seedu.address.testutil.TypicalPatients.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_CONTENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_TITLE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_TITLE_BOB;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PATIENT;
+import static seedu.address.testutil.TypicalPatients.getTypicalAddressBook;
 
-// import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Test;
 
-// import seedu.address.model.Model;
-// import seedu.address.model.ModelManager;
-// import seedu.address.model.UserPrefs;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.note.Note;
 
-// /**
-//  * Contains integration tests (interaction with the Model) and unit tests for
-//  * RemarkCommand.
-//  */
-// public class NoteCommandTest {
 
-//     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * RemarkCommand.
+ */
+public class NoteCommandTest {
 
-//     @Test
-//     public void execute() {
-//         assertCommandFailure(new NoteCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
-//     }
-// }
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        final NoteCommand standardCommand = new NoteCommand(INDEX_FIRST_PATIENT,
+                new Note(VALID_NOTE_TITLE_AMY, VALID_NOTE_CONTENT_AMY));
+
+        // same values -> returns true
+        NoteCommand commandWithSameValues = new NoteCommand(INDEX_FIRST_PATIENT,
+                new Note(VALID_NOTE_TITLE_AMY, VALID_NOTE_CONTENT_AMY));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new NoteCommand(INDEX_SECOND_PATIENT,
+                new Note(VALID_NOTE_TITLE_AMY, VALID_NOTE_CONTENT_AMY))));
+
+        // different title -> returns false
+        assertFalse(standardCommand.equals(new NoteCommand(INDEX_FIRST_PATIENT,
+                new Note(VALID_NOTE_TITLE_BOB, VALID_NOTE_CONTENT_AMY))));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -18,9 +18,13 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -30,8 +34,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPatients.AMY;
-import static seedu.address.testutil.TypicalPatients.BOB;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,20 +50,51 @@ import seedu.address.testutil.PatientBuilder;
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
 
+    // @Test
+    // public void parse_allFieldsPresent_success() {
+    // Patient expectedPatient = new
+    // PatientBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+
+    // // whitespace only preamble
+    // assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB +
+    // PHONE_DESC_BOB + EMAIL_DESC_BOB
+    // + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPatient));
+
+    // // multiple tags - all accepted
+    // Patient expectedPatientMultipleTags = new
+    // PatientBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+    // .build();
+    // assertParseSuccess(parser,
+    // NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB +
+    // TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+    // new AddCommand(expectedPatientMultipleTags));
+    // }
     @Test
     public void parse_allFieldsPresent_success() {
-        Patient expectedPatient = new PatientBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        // Expected patient should NOT have any notes — build from scratch
+        Patient expectedPatient = new PatientBuilder()
+                .withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_FRIEND)
+                .build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPatient));
 
-
         // multiple tags - all accepted
-        Patient expectedPatientMultipleTags = new PatientBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+        Patient expectedPatientMultipleTags = new PatientBuilder()
+                .withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND
+                        + TAG_DESC_FRIEND,
                 new AddCommand(expectedPatientMultipleTags));
     }
 
@@ -131,8 +164,15 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Patient expectedPatient = new PatientBuilder(AMY).withTags().build();
+        // zero tags, and also empty notes
+        Patient expectedPatient = new PatientBuilder()
+                .withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY)
+                .withAddress(VALID_ADDRESS_AMY)
+                .withTags() // empty tags
+                .build();
+
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPatient));
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.patient.NameContainsKeywordsPredicate;
 import seedu.address.model.patient.Patient;
@@ -97,5 +98,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+
+    @Test
+    public void parseCommand_note() throws Exception {
+        assertTrue(parser.parseCommand(NoteCommand.COMMAND_WORD) instanceof NoteCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
 
@@ -24,6 +26,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.note.Note;
 import seedu.address.model.patient.NameContainsKeywordsPredicate;
 import seedu.address.model.patient.Patient;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
@@ -101,7 +104,13 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_note() throws Exception {
-        assertTrue(parser.parseCommand(NoteCommand.COMMAND_WORD) instanceof NoteCommand);
+     public void parseCommand_remark() throws Exception {
+        final Note note = new Note("Some title", "Some content");
+
+        NoteCommand command = (NoteCommand) parser.parseCommand(NoteCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PATIENT.getOneBased() + " " + PREFIX_NOTE_TITLE + note.getTitle()
+                + " " + PREFIX_NOTE_CONTENT + note.getContent());
+        assertEquals(new NoteCommand(INDEX_FIRST_PATIENT, note), command);
     }
+
 }

--- a/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.NoteCommand;
+import seedu.address.model.note.Note;
+
+public class NoteCommandParserTest {
+    private NoteCommandParser parser = new NoteCommandParser();
+    private final String nonEmptyTitle = "Some title.";
+    private final String nonEmptyContent = "Some content.";
+
+    @Test
+    public void parse_indexSpecified_success() {
+        // have remark
+        Index targetIndex = INDEX_FIRST_PATIENT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_NOTE_TITLE + " "
+                + nonEmptyTitle + " " + PREFIX_NOTE_CONTENT + " " + nonEmptyContent;
+        NoteCommand expectedCommand = new NoteCommand(INDEX_FIRST_PATIENT, new Note(nonEmptyTitle, nonEmptyContent));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE);
+
+        // no parameters
+        assertParseFailure(parser, NoteCommand.COMMAND_WORD, expectedMessage);
+
+        // no index
+        assertParseFailure(parser, NoteCommand.COMMAND_WORD + " " + nonEmptyTitle, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/model/note/NoteTest.java
+++ b/src/test/java/seedu/address/model/note/NoteTest.java
@@ -1,0 +1,21 @@
+package seedu.address.model.note;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class NoteTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Note(null, null));
+    }
+
+    @Test
+    public void constructor_invalidTitleAndContent_throwsIllegalArgumentException() {
+        String invalidTitle = "";
+        String invalidContent = "";
+        assertThrows(IllegalArgumentException.class, () -> new Note(invalidTitle, invalidContent));
+    }
+    
+}

--- a/src/test/java/seedu/address/model/note/NoteTest.java
+++ b/src/test/java/seedu/address/model/note/NoteTest.java
@@ -1,21 +1,27 @@
 package seedu.address.model.note;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class NoteTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Note(null, null));
-    }
+    public void equals() {
+        Note note = new Note("Title", "Content");
 
-    @Test
-    public void constructor_invalidTitleAndContent_throwsIllegalArgumentException() {
-        String invalidTitle = "";
-        String invalidContent = "";
-        assertThrows(IllegalArgumentException.class, () -> new Note(invalidTitle, invalidContent));
+        // same object -> returns true
+        assertTrue(note.equals(note));
+
+        // different types -> returns false
+        assertFalse(note.equals(1));
+
+        // null -> returns false
+        assertFalse(note.equals(null));
+
+        // different Note -> returns false
+        Note differentNote = new Note("Different Title", "Different Content");
+        assertFalse(note.equals(differentNote));
     }
-    
 }

--- a/src/test/java/seedu/address/model/patient/PatientTest.java
+++ b/src/test/java/seedu/address/model/patient/PatientTest.java
@@ -93,7 +93,7 @@ public class PatientTest {
     @Test
     public void toStringMethod() {
         String expected = Patient.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + ", notes=" + ALICE.getNotes() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/patient/PatientTest.java
+++ b/src/test/java/seedu/address/model/patient/PatientTest.java
@@ -92,8 +92,12 @@ public class PatientTest {
 
     @Test
     public void toStringMethod() {
-        String expected = Patient.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + ", notes=" + ALICE.getNotes() + "}";
+        String expected = Patient.class.getCanonicalName() + "{name=" + ALICE.getName()
+                + ", phone=" + ALICE.getPhone()
+                + ", email=" + ALICE.getEmail()
+                + ", address=" + ALICE.getAddress()
+                + ", tags=" + ALICE.getTags()
+                + ", notes=" + ALICE.getNotes() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPatientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPatientTest.java
@@ -5,6 +5,7 @@ import static seedu.address.storage.JsonAdaptedPatient.MISSING_FIELD_MESSAGE_FOR
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPatients.BENSON;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,8 @@ public class JsonAdaptedPatientTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_NOTE_TITLE = "";
+    private static final String INVALID_NOTE_CONTENT = "";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -30,6 +33,9 @@ public class JsonAdaptedPatientTest {
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList());
+    private static final List<JsonAdaptedNote> VALID_NOTES = BENSON.getNotes().stream()
+            .map(JsonAdaptedNote::new)
             .collect(Collectors.toList());
 
     @Test
@@ -41,14 +47,15 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPatient patient =
-                new JsonAdaptedPatient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPatient patient = new JsonAdaptedPatient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPatient patient =
+                new JsonAdaptedPatient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
@@ -56,14 +63,15 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPatient patient =
-                new JsonAdaptedPatient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPatient patient = new JsonAdaptedPatient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPatient patient =
+                new JsonAdaptedPatient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
@@ -71,14 +79,15 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPatient patient =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPatient patient = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPatient patient =
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
@@ -86,14 +95,15 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPatient patient =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPatient patient = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPatient patient =
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, patient::toModelType);
     }
@@ -103,7 +113,16 @@ public class JsonAdaptedPatientTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPatient patient =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_NOTES);
+        assertThrows(IllegalValueException.class, patient::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidNotes_throwsIllegalValueException() {
+        List<JsonAdaptedNote> invalidNotes = new ArrayList<>(VALID_NOTES);
+        invalidNotes.add(new JsonAdaptedNote(INVALID_NOTE_TITLE, INVALID_NOTE_CONTENT, LocalDateTime.now()));
+        JsonAdaptedPatient patient =
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, invalidNotes);
         assertThrows(IllegalValueException.class, patient::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PatientBuilder.java
+++ b/src/test/java/seedu/address/testutil/PatientBuilder.java
@@ -1,8 +1,11 @@
 package seedu.address.testutil;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
+import seedu.address.model.note.Note;
 import seedu.address.model.patient.Address;
 import seedu.address.model.patient.Email;
 import seedu.address.model.patient.Name;
@@ -20,12 +23,16 @@ public class PatientBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_TITLE = "Note Title";
+    public static final String DEFAULT_CONTENT = "Note Content";
+    public static final Note DEFAULT_NOTE = new Note(DEFAULT_TITLE, DEFAULT_CONTENT);
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private Set<Tag> tags;
+    private TreeSet<Note> notes;
 
     /**
      * Creates a {@code PatientBuilder} with the default details.
@@ -36,6 +43,7 @@ public class PatientBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        notes = new TreeSet<>();
     }
 
     /**
@@ -47,6 +55,7 @@ public class PatientBuilder {
         email = patientToCopy.getEmail();
         address = patientToCopy.getAddress();
         tags = new HashSet<>(patientToCopy.getTags());
+        notes = new TreeSet<>(patientToCopy.getNotes());
     }
 
     /**
@@ -89,8 +98,16 @@ public class PatientBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Note} of the {@code Patient} that we are building.
+     */
+    public PatientBuilder withNotes(Note... notes) {
+        this.notes.addAll(Arrays.asList(notes));
+        return this;
+    }
+
     public Patient build() {
-        return new Patient(name, phone, email, address, tags);
+        return new Patient(name, phone, email, address, tags, notes);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatients.java
@@ -11,30 +11,51 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.note.Note;
 import seedu.address.model.patient.Patient;
 
 /**
- * A utility class containing a list of {@code Patient} objects to be used in tests.
+ * A utility class containing a list of {@code Patient} objects to be used in
+ * tests.
  */
 public class TypicalPatients {
 
     public static final Patient ALICE = new PatientBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withTags("friends").build();
+            .withTags("friends")
+            .withNotes(
+                    new Note("4th Session with Alice",
+                            "Discussed progress",
+                            LocalDateTime.parse("2023-03-11T12:00:00")))
+            .build();
     public static final Patient BENSON = new PatientBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends")
+            .withNotes(
+                    new Note("Benson is a piece of work",
+                            "He has many issues",
+                            LocalDateTime.parse("2025-03-11T12:00:00")))
+            .build();
     public static final Patient CARL = new PatientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
-    public static final Patient DANIEL = new PatientBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+    public static final Patient DANIEL = new PatientBuilder().withName("Daniel Meier")
+            .withPhone("87652533")
+            .withEmail("cornelia@example.com")
+            .withAddress("10th street")
+            .withTags("friends")
+            .withNotes(
+                    new Note("Daniel owes me money",
+                            "He owes me $4000",
+                            LocalDateTime.parse("2025-03-12T12:00:00")))
+            .build();
     public static final Patient ELLE = new PatientBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Patient FIONA = new PatientBuilder().withName("Fiona Kunz").withPhone("9482427")
@@ -57,7 +78,8 @@ public class TypicalPatients {
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
-    private TypicalPatients() {} // prevents instantiation
+    private TypicalPatients() {
+    } // prevents instantiation
 
     /**
      * Returns an {@code AddressBook} with all the typical patients.


### PR DESCRIPTION
# Builds towards #36 , implementing the functionality for adding notes to a patient
![Dancing Wooper](https://gifdb.com/images/high/cute-wooper-dancing-r7f1b7m529a196ew.gif)

### Achieved in this PR:
- Adds **user story**: As a psychiatrist, I can add notes to a patient so that I can keep track of what was discussed during our sessions.
- Users can now use the command: `note [INDEX] nt/[NOTE TITLE] nc/[NOTE CONTENT]` to add notes to specific patients
- Users are not allowed to edit notes
- Unit, Integration and Regression Tests passed for this new feature

### To improve on:
- Improve on UI by display note titles under each person with separation and individual bubbles, similar to tags
- Error handling: Display error message when invalid note command is given
- Add note message: Include note titles in success message when adding a note to a person
- Add more tests to cover the code introduced
- Future issues and enhancements:
  - Delete Note functionality
  - Update Note functionality
  - View all notes for one patient functionality

## How is it implemented?
1. Each note is one `Note` object, which contains the fields `String title, String content, LocalDateTime dateTimeCreated`
2. Notes are immutable
3. Each Patient maintains a `TreeSet<Note>` of note objects, ordered by their `dateTimeCreated` field. I chose to implement with TreeSet to efficiently maintain the notes in sorted order, while also facilitating efficient filter queries (to be added in later sprints!)
4. NoteCommand and NoteCommandParser follow roughly the same logic as the other commands and command parser classes