### PR TITLE
Add note tite and content when adding or modifying data

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,8 +5,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
-import seedu.address.model.patient.Patient;
 import seedu.address.model.note.Note;
+import seedu.address.model.patient.Patient;
 
 /**
  * Container for user visible messages.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import seedu.address.model.note.Note;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.patient.Patient;
 
@@ -43,6 +44,8 @@ public class Messages {
                 .append(patient.getEmail())
                 .append("; Address: ")
                 .append(patient.getAddress())
+                .append("; \nNotes: ")
+                .append(patient.getNotes().stream().map(Note::getTitledContent).collect(Collectors.joining(", ")))
                 .append("; Tags: ");
         patient.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -4,9 +4,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import seedu.address.model.note.Note;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.patient.Patient;
+import seedu.address.model.note.Note;
 
 /**
  * Container for user visible messages.

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -73,6 +73,14 @@ public class Note implements Comparable<Note> {
     }
 
     /**
+     * Gets content of a note
+     * @return content of the note
+     */
+    public String getTitledContent() {
+        return "[" + this.title + "]" + this.content;
+    }
+
+    /**
      * Gets the date and time the note was created
      * @return LocalDateTime object, which stores the date and time the note was created
      */


### PR DESCRIPTION
resolve #54 
we can now see the new note being added by the user in the results window

* add `getTitledContent()` helper method to Note class
* modify the `format()` method in the Messages.class to also show the patient's note Title and Content

here we can see that when adding Chars2ndNote, the results window shows the feedback
![image](https://github.com/user-attachments/assets/8a7a2663-6101-44dc-a519-85eb5567e1cf)
