### PR TITLE
Add Edit Note command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -1,0 +1,139 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.EditCommand.MESSAGE_DUPLICATE_PATIENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATIENTS;
+import static seedu.address.model.note.Note.isValidNote;
+
+import java.util.List;
+import java.util.TreeSet;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.note.Note;
+import seedu.address.model.patient.Patient;
+
+/**
+ * Edit a specified note of a specified patient.
+ */
+public class EditNoteCommand extends Command {
+    public static final String COMMAND_WORD = "editnote";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Edits the notes of the person identified "
+        + "by the index number used in the last person listing. "
+        + "Existing note will be overwritten by the input.\n"
+        + "Parameters: USER_INDEX (must be a positive integer) "
+        + PREFIX_NOTE_TITLE + "[NOTE TITLE] "
+        + PREFIX_NOTE_CONTENT + "[NOTE CONTENT]\n"
+        + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NOTE_TITLE + "Patient has allergies! "
+        + PREFIX_NOTE_CONTENT + "Allergies include:\n - Shellfish\n - Mushrooms";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
+        "editnote command not implemented yet";
+    public static final String MESSAGE_ARGUMENTS = "UserIndex: %1$d, ListIndex: %1$d, Content: %3$s";
+    public static final String MESSAGE_NOTE_NOT_FOUND = "Note Title cannot be found: %1$s";
+    public static final String MESSAGE_NO_NOTES = "Patient %1$s has no notes";
+    public static final String MESSAGE_BLANK_OR_EMPTY_NOTE = "Note Title and Contents cannot be empty or whitespaces";
+    public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited note of Person: %1$s";
+
+    private final Index userIndex;
+    private final String noteTitle;
+    private final String content;
+
+    /**
+     * Creates an EditNoteCommand object
+     * @param userIndex
+     * @param noteTitle
+     * @param content
+     */
+    public EditNoteCommand(Index userIndex, String noteTitle, String content) {
+        requireAllNonNull(userIndex, noteTitle, content);
+
+        this.userIndex = userIndex;
+        this.noteTitle = noteTitle;
+        this.content = content;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Patient> lastShownList = model.getFilteredPatientList();
+
+        if (userIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+        }
+        if (isValidNote(noteTitle, content) == false) {
+            throw new CommandException(MESSAGE_BLANK_OR_EMPTY_NOTE + noteTitle + content);
+        }
+
+        Patient patientToEdit = lastShownList.get(userIndex.getZeroBased());
+        // Copy existing notes, delete note, add note, send it back
+        TreeSet<Note> updatedNotes = patientToEdit.getNotes();
+        if (updatedNotes.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_NOTES);
+        }
+
+        Note deleteNote = null;
+        for (Note i: updatedNotes) {
+            if (i.getTitle().equalsIgnoreCase(noteTitle)) {
+                deleteNote = i;
+                break;
+            }
+        }
+        if (deleteNote == null) {
+            throw new CommandException(String.format(MESSAGE_NOTE_NOT_FOUND, noteTitle));
+        }
+
+        patientToEdit.getNotes().remove(deleteNote);
+        Note editedNote = new Note(noteTitle, content);
+        updatedNotes.add(editedNote);
+
+        // Create updated patient
+        Patient editedPatient = new Patient(
+                patientToEdit.getName(),
+                patientToEdit.getPhone(),
+                patientToEdit.getEmail(),
+                patientToEdit.getAddress(),
+                patientToEdit.getTags(),
+                updatedNotes);
+
+        if (!patientToEdit.isSamePatient(editedPatient) && model.hasPatient(editedPatient)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PATIENT);
+        }
+
+        model.setPatient(patientToEdit, editedPatient);
+        model.updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
+
+        return new CommandResult(generateSuccessMessage(editedPatient));
+    }
+
+    /**
+     * Generates a command execution success message when a note is edited.
+     */
+    private String generateSuccessMessage(Patient patientToEdit) {
+        return String.format(MESSAGE_EDIT_NOTE_SUCCESS, Messages.format(patientToEdit));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditNoteCommand)) {
+            return false;
+        }
+
+        EditNoteCommand e = (EditNoteCommand) other;
+        return userIndex.equals(e.userIndex)
+                && noteTitle.equals(e.noteTitle)
+                && content.equals(e.content);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -13,7 +13,6 @@ import java.util.TreeSet;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.note.Note;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditNoteCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterNoteCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case ViewNotesCommand.COMMAND_WORD:
             return new ViewNotesCommandParser().parse(arguments);
+
+        case EditNoteCommand.COMMAND_WORD:
+            return new EditNoteCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/EditNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditNoteCommandParser.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.EditNoteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditNoteCommand object.
+ */
+public class EditNoteCommandParser implements Parser<EditNoteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditNoteCommand
+     * and returns an EditNoteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditNoteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+            PREFIX_NOTE_TITLE, PREFIX_NOTE_CONTENT);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditNoteCommand.MESSAGE_USAGE), ive);
+        }
+
+        String noteTitle = argMultimap.getValue(PREFIX_NOTE_TITLE).orElse("");
+        String content = argMultimap.getValue(PREFIX_NOTE_CONTENT).orElse("");
+
+        return new EditNoteCommand(index, noteTitle, content);
+    }
+}

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -55,8 +55,15 @@ public class Note implements Comparable<Note> {
         this.dateTimeCreated = dateTimeCreated;
     }
 
+    /**
+     * Check if a note's title and contents are empty or whitespace
+     * @param title
+     * @param content
+     * @return
+     */
     public static boolean isValidNote(String title, String content) {
-        return !title.isEmpty() && !content.isEmpty();
+        // trim to make sure that title and content is not just whitespace
+        return !title.trim().isEmpty() && !content.trim().isEmpty();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditNoteCommandTest.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_CONTENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_CONTENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_TITLE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_TITLE_BOB;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PATIENT;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * EditNoteCommand.
+ */
+public class EditNoteCommandTest {
+    /**
+     * Test equals function
+     */
+    @Test
+    public void equals() {
+        final EditNoteCommand standardCommand =
+            new EditNoteCommand(INDEX_FIRST_PATIENT, VALID_NOTE_TITLE_BOB, VALID_NOTE_CONTENT_BOB);
+
+        // same values -> returns true
+        EditNoteCommand commandWithSameValues =
+            new EditNoteCommand(INDEX_FIRST_PATIENT, VALID_NOTE_TITLE_BOB, VALID_NOTE_CONTENT_BOB);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(
+            new EditNoteCommand(INDEX_SECOND_PATIENT, VALID_NOTE_TITLE_BOB, VALID_NOTE_CONTENT_BOB)));
+
+        // different note title and content -> returns false
+        assertFalse(standardCommand.equals(
+            new EditNoteCommand(INDEX_FIRST_PATIENT, VALID_NOTE_TITLE_AMY, VALID_NOTE_CONTENT_AMY)));
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditNoteCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterNoteCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -135,5 +136,15 @@ public class AddressBookParserTest {
         FilterNoteCommand command = (FilterNoteCommand) parser.parseCommand(FilterNoteCommand.COMMAND_WORD
                         + " " + INDEX_FIRST_PATIENT.getOneBased() + " " + PREFIX_NOTE_TITLE + "test");
         assertEquals(new FilterNoteCommand(INDEX_FIRST_PATIENT, "test"), command);
+    }
+
+    @Test
+    public void parseCommand_editNotes() throws Exception {
+        final Note note = new Note("Some title", "Some content");
+
+        EditNoteCommand command = (EditNoteCommand) parser.parseCommand(EditNoteCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PATIENT.getOneBased() + " " + PREFIX_NOTE_TITLE + note.getTitle()
+                + " " + PREFIX_NOTE_CONTENT + note.getContent());
+        assertEquals(new EditNoteCommand(INDEX_FIRST_PATIENT, note.getTitle(), note.getContent()), command);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditNoteCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditNoteCommand;
+
+public class EditNoteCommandParserTest {
+    private final EditNoteCommandParser parser = new EditNoteCommandParser();
+    private final String nonEmptyTitle = "Some title.";
+    private final String nonEmptyContent = "Some content.";
+
+    @Test
+    public void parse_indexSpecified_success() {
+        // have remark
+        Index targetIndex = INDEX_FIRST_PATIENT;
+        String userInput = targetIndex.getOneBased() + " "
+            + PREFIX_NOTE_TITLE + nonEmptyTitle + " "
+            + PREFIX_NOTE_CONTENT + nonEmptyContent;
+        EditNoteCommand expectedCommand =
+            new EditNoteCommand(INDEX_FIRST_PATIENT, nonEmptyTitle, nonEmptyContent);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditNoteCommand.MESSAGE_USAGE);
+        Index targetIndex = INDEX_FIRST_PATIENT;
+
+        // no parameters
+        assertParseFailure(parser, EditNoteCommand.COMMAND_WORD, expectedMessage);
+
+        // no index
+        assertParseFailure(parser, EditNoteCommand.COMMAND_WORD + " " + PREFIX_NOTE_TITLE
+            + nonEmptyTitle, expectedMessage);
+
+        // no title
+        assertParseFailure(parser, EditNoteCommand.COMMAND_WORD + " "
+            + targetIndex.getOneBased()
+            + PREFIX_NOTE_TITLE, expectedMessage);
+
+        // no title
+        assertParseFailure(parser, EditNoteCommand.COMMAND_WORD + " "
+            + targetIndex.getOneBased()
+            + PREFIX_NOTE_TITLE + nonEmptyTitle
+            + PREFIX_NOTE_CONTENT + nonEmptyContent, expectedMessage);
+    }
+}


### PR DESCRIPTION
Added the function to edit notes

Format: editnote [USER INDEX] nt/[NOTE TITLE] nc/[NOTE CONTENTS]

User index has to be valid, taken from last shown list.
Note title is a unique key, has to be one of the existing note titles.
Note contents can be any string.

Future tasks:
- need to add documentation to user guide
- need to add documentation to technical guide

Closes #48 