### PR TITLE
Add deletenote sequence diagram

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -101,6 +101,13 @@ The sequence diagram below illustrates the interactions within the `Logic` compo
 <div markdown="span" class="alert alert-info">:information_source: **Note:** The lifeline for `DeleteCommandParser` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline continues till the end of diagram.
 </div>
 
+The sequence diagram below illustrates the interactions within the `Logic` component, taking `execute("deletenote 1 nt/JohnAngry")` API call as an example.
+
+![Interactions Inside the Logic Component for the `deletenote 1 nt/JohnAngry` Command](images/DeleteNoteSequenceDiagram.png)
+
+<div markdown="span" class="alert alert-info">:information_source: **Note:** The lifeline for `DeleteNoteCommandParser` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline continues till the end of diagram.
+</div>
+
 How the `Logic` component works:
 
 1. When `Logic` is called upon to execute a command, it is passed to an `AddressBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteCommandParser`) and uses it to parse the command.

--- a/docs/diagrams/DeleteNoteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteNoteSequenceDiagram.puml
@@ -1,0 +1,70 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":DeleteNoteCommandParser" as DeleteNoteCommandParser LOGIC_COLOR
+participant "dn:DeleteNoteCommand" as DeleteNoteCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("deleteNote 1 nt/JohnAngry")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("deleteNote 1 nt/JohnAngry")
+activate AddressBookParser
+
+create DeleteNoteCommandParser
+AddressBookParser -> DeleteNoteCommandParser
+activate DeleteNoteCommandParser
+
+DeleteNoteCommandParser --> AddressBookParser
+deactivate DeleteNoteCommandParser
+
+AddressBookParser -> DeleteNoteCommandParser : parse("1 nt/JohnAngry")
+activate DeleteNoteCommandParser
+
+create DeleteNoteCommand
+DeleteNoteCommandParser -> DeleteNoteCommand
+activate DeleteNoteCommand
+
+DeleteNoteCommand --> DeleteNoteCommandParser :
+deactivate DeleteNoteCommand
+
+DeleteNoteCommandParser --> AddressBookParser : dn
+deactivate DeleteNoteCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+DeleteNoteCommandParser -[hidden]-> AddressBookParser
+destroy DeleteNoteCommandParser
+
+AddressBookParser --> LogicManager : dn
+deactivate AddressBookParser
+
+LogicManager -> DeleteNoteCommand : execute(m)
+activate DeleteNoteCommand
+
+DeleteNoteCommand -> Model : setPatient(toEdit, edited)
+activate Model
+
+Model --> DeleteNoteCommand
+deactivate Model
+
+create CommandResult
+DeleteNoteCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> DeleteNoteCommand
+deactivate CommandResult
+
+DeleteNoteCommand --> LogicManager : r
+deactivate DeleteNoteCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
# Add DeleteNote Sequence Diagram
- A new PlantUML (.puml) file detailing the deletenote command flow
- An updated developer guide with a screenshot of the rendered sequence diagram

These additions aim to improve the understanding of the deletenote command's internal workings for both current and future developers.

resolves #104 