### PR TITLE
Update Input Validations

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,10 +23,13 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in the app";
     public static final String MESSAGE_NOTE_NOT_FOUND = "Note Title does not exist: %1$s";
     public static final String MESSAGE_NO_NOTES = "Patient %1$s has no notes";
-    public static final String MESSAGE_NOT_ADDED_NOTE = "Note must have title and content! ";
+    public static final String MESSAGE_NOT_ADDED_NOTE = "Note must have title and content!";
     public static final String MESSAGE_INVALID_INDEX = "Invalid index! Please provide a positive integer within range.";
     public static final String MESSAGE_UNDO_FAILURE = "No command to undo!";
     public static final String MESSAGE_REDO_FAILURE = "No command to redo!";
+    public static final String MESSAGE_SPECIAL_CHARACTERS = "Command contains special characters.\n"
+                + "Only letters, numbers, and spaces are allowed.\n%1$s";
+    public static final String ALPHANUMERIC_REGEX = "^[a-zA-Z0-9\\s]+$";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -30,8 +30,8 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "Schizophrenia "
+            + PREFIX_TAG + "Anxiety";
 
     public static final String MESSAGE_SUCCESS = "New patient added: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -28,7 +28,7 @@ public class DeleteNoteCommand extends Command {
             + ": Deletes a specified note of a patient identified by the title string used "
             + "in the displayed note list.\n"
             + "Parameters: INDEX (must be a positive integer) nt/TITLE (must be a valid string)\n"
-            + "Example: " + COMMAND_WORD + " 1 nt/JohnFirstCrashout";
+            + "Example: " + COMMAND_WORD + " 1 nt/Session 32";
 
     public static final String MESSAGE_DELETE_PATIENT_NOTE_SUCCESS = "Deleted Note of Patient: %1$s";
 
@@ -65,7 +65,7 @@ public class DeleteNoteCommand extends Command {
         TreeSet<Note> newCopyNotes = new TreeSet<>(allNotes);
 
         if (newCopyNotes.isEmpty()) {
-            throw new CommandException(MESSAGE_NO_NOTES);
+            throw new CommandException(String.format(MESSAGE_NO_NOTES, targetIndex.getOneBased()));
         }
 
         Note matchingNote = newCopyNotes.stream()

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -34,7 +34,7 @@ public class EditNoteCommand extends Command {
         + PREFIX_NOTE_TITLE + "[NOTE TITLE] "
         + PREFIX_NOTE_CONTENT + "[NOTE CONTENT]\n"
         + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NOTE_TITLE + "Patient has allergies! "
-        + PREFIX_NOTE_CONTENT + "Allergies include:\n - Shellfish\n - Mushrooms";
+        + PREFIX_NOTE_CONTENT + "Allergies include: Shellfish, Mushrooms";
 
     public static final String MESSAGE_ARGUMENTS = "UserIndex: %1$d, ListIndex: %1$d, Content: %3$s";
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited note of Person: %1$s";
@@ -66,7 +66,7 @@ public class EditNoteCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
         }
         if (isValidNote(noteTitle, content) == false) {
-            throw new CommandException(MESSAGE_NOT_ADDED_NOTE + noteTitle + content);
+            throw new CommandException(MESSAGE_NOT_ADDED_NOTE);
         }
 
         Patient patientToEdit = lastShownList.get(userIndex.getZeroBased());
@@ -74,7 +74,7 @@ public class EditNoteCommand extends Command {
         TreeSet<Note> updatedNotes = patientToEdit.getNotes();
         TreeSet<Note> newCopyNotes = new TreeSet<>(updatedNotes);
         if (newCopyNotes.isEmpty()) {
-            throw new CommandException(MESSAGE_NO_NOTES);
+            throw new CommandException(String.format(MESSAGE_NO_NOTES, userIndex.getOneBased()));
         }
 
         Note deleteNote = null;

--- a/src/main/java/seedu/address/logic/commands/FilterNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterNoteCommand.java
@@ -59,7 +59,7 @@ public class FilterNoteCommand extends Command {
         TreeSet<Note> allNotes = patientToFilter.getNotes();
 
         if (allNotes.isEmpty()) {
-            throw new CommandException(MESSAGE_NO_NOTES);
+            throw new CommandException(String.format(MESSAGE_NO_NOTES, index.getOneBased()));
         }
 
         List<Note> matchingNotes = allNotes.stream()

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -28,8 +28,8 @@ public class NoteCommand extends Command {
             + PREFIX_NOTE_TITLE + "[NOTE TITLE] "
             + PREFIX_NOTE_CONTENT + "[NOTE CONTENT]\n"
             + "Example: " + COMMAND_WORD + " 1"
-            + PREFIX_NOTE_TITLE + "Patient has allergies!"
-            + PREFIX_NOTE_CONTENT + "Allergies include:\n - Penicillin\n - Nuts";
+            + PREFIX_NOTE_TITLE + "Patient has allergies! "
+            + PREFIX_NOTE_CONTENT + "Allergies include: Penicillin, Nuts";
     public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Note Title: %2$s, Note Content: %3$s";
     public static final String MESSAGE_ADD_NOTE_SUCCESS = "Added note to Person: %1$s";
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -30,9 +30,10 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        args = args.trim();
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS, PREFIX_TAG);
-
         Index index;
 
         try {
@@ -42,7 +43,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS);
-
         EditPatientDescriptor editPatientDescriptor = new EditPatientDescriptor();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/ViewNotesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewNotesCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.ALPHANUMERIC_REGEX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_SPECIAL_CHARACTERS;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewNotesCommand;
@@ -10,10 +12,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new ViewNotesCommand object.
  */
 public class ViewNotesCommandParser implements Parser<ViewNotesCommand> {
-
-    public static final String MESSAGE_SPECIAL_CHARACTERS = "Command contains special characters.\n"
-            + "Only letters, numbers, and spaces are allowed.\n%1$s";
-    private static final String VALID_INPUT_REGEX = "^[a-zA-Z0-9\\s]+$";
 
     /**
      * Parses the given {@code String} of arguments in the context of the
@@ -34,7 +32,7 @@ public class ViewNotesCommandParser implements Parser<ViewNotesCommand> {
         }
 
         // Check for special characters before any other validation
-        if (!trimmedArgs.matches(VALID_INPUT_REGEX)) {
+        if (!trimmedArgs.matches(ALPHANUMERIC_REGEX)) {
             throw new ParseException(
                     String.format(MESSAGE_SPECIAL_CHARACTERS, ViewNotesCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/patient/Name.java
+++ b/src/main/java/seedu/address/model/patient/Name.java
@@ -10,13 +10,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
-
+            "Names should only contain alphanumeric and the following: , . ' "
+            + "- and whitespace (case-insensitive)\n"
+            + "Additionally, <name> s/o <parents's name> is allowed. (includes d/o, case insensitive)";
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9,.'-]+(?: [a-zA-Z0-9,.'-]+)*"
+            + "( (?:[sS]/[oO]|[dD]/[oO]) [a-zA-Z0-9,.'-]+(?: [a-zA-Z0-9,.'-]+)*)?$";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/logic/parser/ViewNotesCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewNotesCommandParserTest.java
@@ -1,9 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_SPECIAL_CHARACTERS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ViewNotesCommandParser.MESSAGE_SPECIAL_CHARACTERS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/model/patient/PatientTest.java
+++ b/src/test/java/seedu/address/model/patient/PatientTest.java
@@ -43,11 +43,6 @@ public class PatientTest {
         // name differs in case, all other attributes same -> returns false
         Patient editedBob = new PatientBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertFalse(BOB.isSamePatient(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PatientBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePatient(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Name now allows certain special characters including s/o, d/o
Names should only contain alphanumeric and the following: , . ' - and whitespace (case-insensitive)
Additionally, <name> s/o <parents's name> is allowed. (includes d/o, case insensitive)
Closes #116
Closes #118
Closes #131 
Closes #45 

Fix some bugs with wrong error messages on EditNoteCommand, DeleteNotecommand, FilterNoteCommand
Closes #134 
Closes #121 

Change some example commands, which are not relevant to the context of this application
Closes #120 

